### PR TITLE
Amend python from 3.6 to 3.9 for SRQ0798483

### DIFF
--- a/lambda.tf
+++ b/lambda.tf
@@ -4,7 +4,7 @@ module "lambda" {
   function_name = "aws-health-notification-handler"
   description   = "Handles AWS Health notifications"
   handler       = "main.lambda_handler"
-  runtime       = "python3.6"
+  runtime       = "python3.9"
   timeout       = 300
 
   // Specify a file or directory for the source code.


### PR DESCRIPTION
```
This is in regards to SRQ0798483 - to stop python 3.6 from being pushed out
```